### PR TITLE
Add Read Next block to blog posts

### DIFF
--- a/src/app/_components/read-next.tsx
+++ b/src/app/_components/read-next.tsx
@@ -1,0 +1,41 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { Post } from '@/interfaces/post';
+import PostDate from './post-date';
+
+export default function ReadNext({ post }: { post: Post }) {
+    return (
+        <div className="mt-8 pt-8 border-t border-gray-200 dark:border-gray-800">
+            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+                Read Next
+            </h3>
+            <Link 
+                href={`/blog/${encodeURIComponent(post.slug)}`}
+                className="flex flex-col sm:flex-row gap-4 no-underline"
+            >
+                <div className="flex-shrink-0 sm:w-48">
+                    <Image
+                        className="rounded w-full h-auto object-cover"
+                        src={post.cover}
+                        alt={`Cover image for ${post.title}`}
+                        width={800}
+                        height={400}
+                        sizes="(max-width: 640px) 100vw, 192px"
+                        style={{ width: '100%', height: 'auto' }}
+                    />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <h4 className="text-base font-medium text-gray-900 dark:text-gray-100 mb-2">
+                        {post.title}
+                    </h4>
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-2 line-clamp-2">
+                        {post.description}
+                    </p>
+                    <div className="text-xs text-gray-500 dark:text-gray-500">
+                        <PostDate dateString={post.date} />
+                    </div>
+                </div>
+            </Link>
+        </div>
+    );
+}

--- a/src/app/_components/read-next.tsx
+++ b/src/app/_components/read-next.tsx
@@ -28,7 +28,7 @@ export default function ReadNext({ post }: { post: Post }) {
                     <h4 className="text-base font-medium text-gray-900 dark:text-gray-100 mb-2">
                         {post.title}
                     </h4>
-                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-2 line-clamp-2">
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
                         {post.description}
                     </p>
                     <div className="text-xs text-gray-500 dark:text-gray-500">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,8 @@
-import { getPostBySlug, getAllPosts } from '@/lib/api'
+import { getPostBySlug, getAllPosts, getPreviousPost } from '@/lib/api'
 import markdownToHtml from '@/lib/markdownToHtml'
 import PostHeader from '@/app/_components/post-header'
 import PostActions from '@/app/_components/post-actions'
+import ReadNext from '@/app/_components/read-next'
 import AdBlock from '@/app/_components/ad-block'
 import type { Metadata } from 'next'
 import { name } from '@/lib/const'
@@ -11,6 +12,7 @@ export default async function BlogPost(props: Params) {
     const params = await props.params;
     const post = getPostBySlug(params.slug);
     const content = await markdownToHtml(post.content || "");
+    const previousPost = getPreviousPost(params.slug);
     
     
     return (
@@ -31,7 +33,10 @@ export default async function BlogPost(props: Params) {
                     </div>
                 </div>
             </article>
-            <PostActions post={post} />
+            <div className="max-w-2xl mx-auto w-full">
+                <PostActions post={post} />
+                {previousPost && <ReadNext post={previousPost} />}
+            </div>
         </main>
     );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -34,6 +34,17 @@ export function getAllPosts(): Post[] {
     return posts;
 }
 
+export function getPreviousPost(currentSlug: string): Post | null {
+    const posts = getAllPosts();
+    const currentIndex = posts.findIndex(post => post.slug === currentSlug);
+    
+    if (currentIndex === -1 || currentIndex === posts.length - 1) {
+        return null;
+    }
+    
+    return posts[currentIndex + 1];
+}
+
 export function getAllCategories(): string[] {
     const posts = getAllPosts();
     const categoriesSet = new Set<string>();


### PR DESCRIPTION
## Summary
- Adds a "Read Next" block at the bottom of blog posts that shows the previous article chronologically
- Provides seamless navigation between blog posts to increase reader engagement
- Maintains consistent design with existing blog post styling

## Changes
- **New `getPreviousPost()` utility function** in `api.ts` that finds the chronologically previous post
- **New `ReadNext` component** with responsive design that matches blog post preview styling
- **Updated blog post page** to fetch and display previous post when available
- **Proper edge case handling** - no ReadNext block shown for the oldest post

## Technical Details
- Uses existing post sorting logic (by date descending) to determine previous post
- Component uses same image aspect ratio (2:1) as main blog post images
- Responsive design: stacked on mobile, side-by-side on desktop
- Full dark mode support with consistent color scheme
- TypeScript typed with proper null handling

## Test plan
- [x] TypeScript compilation passes without errors
- [x] Linting passes without warnings  
- [x] Development server starts successfully
- [x] Component handles null previous post case
- [x] Responsive design works on different screen sizes
- [x] Dark mode styling applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)