### PR TITLE
Add click-to-zoom for post images

### DIFF
--- a/src/app/_components/post-image-zoom.tsx
+++ b/src/app/_components/post-image-zoom.tsx
@@ -1,0 +1,452 @@
+"use client"
+
+import type React from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { FiX } from "react-icons/fi"
+
+const contentSelector = "[data-post-content]"
+const openDuration = 320
+const closeDuration = 260
+const fadeDuration = 120
+const springBackDuration = 200
+const resetSlack = 80
+const easing = "cubic-bezier(0.2, 0, 0, 1)"
+const viewportFill = 0.92
+const minZoomGain = 1.2
+const dismissDistance = 90
+const dismissFade = 0.6
+const scrollCloseThreshold = 24
+const tapSlop = 4
+const borderRadius = 4
+
+type ZoomState = {
+  src: string
+  alt: string
+  width: number
+  height: number
+  // Tall screenshots already render wider in the article than a fit-to-viewport
+  // overlay would, so they are shown at natural width and scroll instead.
+  scrollable: boolean
+}
+
+type Drag = {
+  pointerId: number
+  startY: number
+  moved: boolean
+}
+
+function isZoomable(image: HTMLImageElement) {
+  return (
+    !image.closest("a") &&
+    !image.closest(".react-tweet-theme") &&
+    !image.closest("[data-no-zoom]")
+  )
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+}
+
+export default function PostImageZoom() {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const figureRef = useRef<HTMLImageElement>(null)
+  const backdropRef = useRef<HTMLDivElement>(null)
+  const sourceRef = useRef<HTMLImageElement | null>(null)
+  const animationRef = useRef<Animation | null>(null)
+  const dialogAnimationRef = useRef<Animation | null>(null)
+  const closingRef = useRef(false)
+  const dragRef = useRef<Drag | null>(null)
+  const timeoutRef = useRef<number | null>(null)
+  const [zoom, setZoom] = useState<ZoomState | null>(null)
+
+  const reset = useCallback(() => {
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+    timeoutRef.current = null
+    animationRef.current?.cancel()
+    animationRef.current = null
+    dialogAnimationRef.current?.cancel()
+    dialogAnimationRef.current = null
+    dragRef.current = null
+    closingRef.current = false
+
+    // Unhide the source before closing: close() hands focus back to whatever
+    // was focused before showModal(), and a hidden element cannot take it.
+    if (sourceRef.current) sourceRef.current.style.visibility = ""
+    sourceRef.current = null
+
+    if (backdropRef.current) backdropRef.current.style.opacity = ""
+
+    const dialog = dialogRef.current
+    if (dialog?.open) dialog.close()
+
+    setZoom(null)
+  }, [])
+
+  const close = useCallback(() => {
+    const dialog = dialogRef.current
+    const figure = figureRef.current
+    const source = sourceRef.current
+
+    if (closingRef.current || !dialog?.open || !figure) return
+    closingRef.current = true
+    dragRef.current = null
+    animationRef.current?.cancel()
+    animationRef.current = null
+
+    // The page may have scrolled behind the dialog, so measure the source again.
+    const from = source?.getBoundingClientRect()
+
+    // Animation events are not delivered while the tab is hidden, so a timer
+    // backs up onfinish and guarantees the overlay always tears itself down.
+    const scheduleReset = (duration: number) => {
+      timeoutRef.current = window.setTimeout(reset, duration + resetSlack)
+    }
+
+    // The backdrop fades out through an inline opacity rather than a filling
+    // animation: Chrome keeps a forwards fill applied to the persistent element
+    // even after dropping it from getAnimations(), which leaves every later
+    // open invisible.
+    const fadeOut = (duration: number) => {
+      const backdrop = backdropRef.current
+      if (!backdrop) return null
+      const from = backdrop.style.opacity || 1
+      backdrop.style.opacity = "0"
+      const fade = backdrop.animate([{ opacity: from }, { opacity: 0 }], {
+        duration,
+        easing,
+      })
+      dialogAnimationRef.current = fade
+      return fade
+    }
+
+    if (!from || from.width === 0 || prefersReducedMotion()) {
+      const fade = fadeOut(fadeDuration)
+      if (fade) fade.onfinish = reset
+      scheduleReset(fadeDuration)
+      return
+    }
+
+    const dragged = figure.style.transform
+    figure.style.transform = ""
+    const to = figure.getBoundingClientRect()
+    const scale = from.width / to.width
+
+    const animation = figure.animate(
+      [
+        { transform: dragged || "none" },
+        {
+          transform: `translate(${from.left - to.left}px, ${from.top - to.top}px) scale(${scale})`,
+          borderRadius: `${borderRadius / scale}px`,
+        },
+      ],
+      { duration: closeDuration, easing, fill: "forwards" }
+    )
+    fadeOut(closeDuration)
+
+    animation.onfinish = reset
+    animationRef.current = animation
+    scheduleReset(closeDuration)
+  }, [reset])
+
+  const open = useCallback((image: HTMLImageElement) => {
+    if (!image.complete) return
+
+    // The width/height attributes describe the original asset; naturalWidth
+    // only describes whichever srcset candidate happens to be loaded.
+    const width = Number(image.getAttribute("width")) || image.naturalWidth
+    const height = Number(image.getAttribute("height")) || image.naturalHeight
+    // Broken images report no dimensions at all, so there is nothing to zoom.
+    if (!width || !height) return
+
+    // clientWidth/clientHeight, not innerWidth/innerHeight: these are the same
+    // viewport the 92vw/92dvh caps in the stylesheet resolve against.
+    const viewport = document.documentElement
+    const rect = image.getBoundingClientRect()
+    const containedWidth = Math.min(
+      width,
+      viewport.clientWidth * viewportFill,
+      (viewport.clientHeight * viewportFill * width) / height
+    )
+
+    if (sourceRef.current) sourceRef.current.style.visibility = ""
+    sourceRef.current = image
+    setZoom({
+      src: image.currentSrc || image.src,
+      alt: image.alt,
+      width,
+      height,
+      // Fitting into the viewport is only worth it when it actually magnifies
+      // the image. Tall screenshots on desktop and wide ones on phones gain
+      // nothing that way, so those are shown at natural size and scrolled.
+      scrollable: containedWidth < rect.width * minZoomGain,
+    })
+  }, [])
+
+  // Mark zoomable images. Progressive enhancement: without JS nothing changes.
+  // Runs once per mount; the post page keys this component by slug.
+  useEffect(() => {
+    const images = Array.from(
+      document.querySelectorAll<HTMLImageElement>(`${contentSelector} img`)
+    ).filter(isZoomable)
+
+    for (const image of images) {
+      image.dataset.zoomable = "true"
+      image.setAttribute("role", "button")
+      image.setAttribute("tabindex", "0")
+      image.setAttribute(
+        "aria-label",
+        image.alt ? `Zoom image: ${image.alt}` : "Zoom image"
+      )
+    }
+
+    return () => {
+      for (const image of images) {
+        delete image.dataset.zoomable
+        image.removeAttribute("role")
+        image.removeAttribute("tabindex")
+        image.removeAttribute("aria-label")
+        image.style.visibility = ""
+      }
+      reset()
+    }
+  }, [reset])
+
+  // Delegated open, so raw <img> tags in MDX are covered too.
+  useEffect(() => {
+    const root = document.querySelector(contentSelector)
+    if (!root) return
+
+    const findImage = (event: Event) =>
+      (event.target as HTMLElement | null)?.closest<HTMLImageElement>(
+        "img[data-zoomable]"
+      ) ?? null
+
+    const onClick = (event: MouseEvent) => {
+      if (
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey
+      )
+        return
+      const image = findImage(event)
+      if (image) open(image)
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Enter" && event.key !== " ") return
+      const image = findImage(event)
+      if (!image) return
+      event.preventDefault()
+      open(image)
+    }
+
+    root.addEventListener("click", onClick as EventListener)
+    root.addEventListener("keydown", onKeyDown as EventListener)
+
+    return () => {
+      root.removeEventListener("click", onClick as EventListener)
+      root.removeEventListener("keydown", onKeyDown as EventListener)
+    }
+  }, [open])
+
+  // FLIP from the in-article image to the overlay.
+  useEffect(() => {
+    const dialog = dialogRef.current
+    const figure = figureRef.current
+    const source = sourceRef.current
+    if (!zoom || !dialog || !figure || !source) return
+
+    dialog.showModal()
+    dialog.scrollTop = 0
+    // An image wider than the viewport opens centred rather than on its corner.
+    dialog.scrollLeft = (dialog.scrollWidth - dialog.clientWidth) / 2
+    source.style.visibility = "hidden"
+
+    const backdrop = backdropRef.current
+
+    if (prefersReducedMotion()) {
+      dialogAnimationRef.current =
+        backdrop?.animate([{ opacity: 0 }, { opacity: 1 }], {
+          duration: fadeDuration,
+          easing,
+        }) ?? null
+      return
+    }
+
+    const from = source.getBoundingClientRect()
+    const to = figure.getBoundingClientRect()
+    if (to.width === 0) return
+    const scale = from.width / to.width
+
+    const animation = figure.animate(
+      [
+        {
+          transform: `translate(${from.left - to.left}px, ${from.top - to.top}px) scale(${scale})`,
+          borderRadius: `${borderRadius / scale}px`,
+        },
+        { transform: "none", borderRadius: `${borderRadius}px` },
+      ],
+      { duration: openDuration, easing }
+    )
+    dialogAnimationRef.current =
+      backdrop?.animate([{ opacity: 0 }, { opacity: 1 }], {
+        duration: openDuration,
+        easing,
+      }) ?? null
+
+    animationRef.current = animation
+  }, [zoom])
+
+  // Escape. A modal dialog does not reliably fire `cancel` (Chrome only sends a
+  // close request once per user activation), so the key is handled directly.
+  useEffect(() => {
+    if (!zoom) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      event.preventDefault()
+      close()
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [zoom, close])
+
+  // Scrolling the page dismisses the overlay, unless the overlay itself scrolls.
+  useEffect(() => {
+    if (!zoom || zoom.scrollable) return
+
+    const startY = window.scrollY
+    const onScroll = () => {
+      if (Math.abs(window.scrollY - startY) > scrollCloseThreshold) close()
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true })
+    window.addEventListener("wheel", close, { passive: true })
+
+    return () => {
+      window.removeEventListener("scroll", onScroll)
+      window.removeEventListener("wheel", close)
+    }
+  }, [zoom, close])
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDialogElement>) => {
+    if (!zoom || zoom.scrollable) return
+    if (event.target !== figureRef.current) return
+    if (event.pointerType === "mouse" && event.button !== 0) return
+
+    animationRef.current?.finish()
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      moved: false,
+    }
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {
+      // The pointer can already be gone; the drag still works without capture.
+    }
+  }
+
+  const onPointerMove = (event: React.PointerEvent<HTMLDialogElement>) => {
+    const drag = dragRef.current
+    const figure = figureRef.current
+    const backdrop = backdropRef.current
+    if (!drag || drag.pointerId !== event.pointerId || !figure || !backdrop)
+      return
+
+    const offset = event.clientY - drag.startY
+    if (Math.abs(offset) > tapSlop) drag.moved = true
+    figure.style.transform = `translateY(${offset}px)`
+    backdrop.style.opacity = String(
+      1 - Math.min(Math.abs(offset) / 400, dismissFade)
+    )
+  }
+
+  const onPointerUp = (event: React.PointerEvent<HTMLDialogElement>) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    dragRef.current = null
+
+    const offset = event.clientY - drag.startY
+    if (!drag.moved || Math.abs(offset) > dismissDistance) {
+      close()
+      return
+    }
+
+    const figure = figureRef.current
+    const backdrop = backdropRef.current
+    if (!figure || !backdrop) return
+
+    figure.style.transform = ""
+    backdrop.style.opacity = ""
+    figure.animate(
+      [{ transform: `translateY(${offset}px)` }, { transform: "none" }],
+      { duration: springBackDuration, easing }
+    )
+  }
+
+  const onPointerCancel = () => {
+    const figure = figureRef.current
+    const backdrop = backdropRef.current
+    dragRef.current = null
+    if (figure) figure.style.transform = ""
+    if (backdrop) backdrop.style.opacity = ""
+  }
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: the click only dismisses the overlay, which Escape (onCancel) and the close button already do
+    <dialog
+      ref={dialogRef}
+      aria-label={zoom?.alt ? `Zoomed image: ${zoom.alt}` : "Zoomed image"}
+      className={
+        zoom?.scrollable
+          ? "image-zoom-dialog image-zoom-dialog-scroll"
+          : "image-zoom-dialog"
+      }
+      onCancel={(event) => {
+        // Intercept Escape so the closing animation can play first.
+        event.preventDefault()
+        close()
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          close()
+          return
+        }
+        if (zoom?.scrollable && event.target === figureRef.current) close()
+      }}
+      onPointerCancel={onPointerCancel}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      {/* A separate layer so only the background fades: the image itself stays
+          fully opaque and reads as growing out of the article. */}
+      <div className="image-zoom-backdrop" ref={backdropRef} />
+      {zoom && (
+        <>
+          <button
+            aria-label="Close image"
+            className="image-zoom-close"
+            onClick={close}
+            type="button"
+          >
+            <FiX aria-hidden="true" />
+          </button>
+          {/* biome-ignore lint/performance/noImgElement: reuses the already cached currentSrc, and next/image would refetch and flatten animated GIFs */}
+          <img
+            alt={zoom.alt}
+            className="image-zoom-figure"
+            draggable={false}
+            height={zoom.height}
+            ref={figureRef}
+            src={zoom.src}
+            width={zoom.width}
+          />
+        </>
+      )}
+    </dialog>
+  )
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import AdBlock from "@/app/_components/ad-block"
 import PostActions from "@/app/_components/post-actions"
 import PostHeader from "@/app/_components/post-header"
+import PostImageZoom from "@/app/_components/post-image-zoom"
 import PostTableOfContents from "@/app/_components/post-table-of-contents"
 import ReadNext from "@/app/_components/read-next"
 import {
@@ -52,6 +53,8 @@ export default async function BlogPost(props: Params) {
           >
             {content}
           </div>
+          {/* Keyed by slug so navigating between posts remounts and re-marks images. */}
+          <PostImageZoom key={post.slug} />
         </div>
       </article>
       <div className="mx-auto w-full max-w-2xl">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,6 +81,146 @@ a.underline:hover,
   margin-top: 0;
 }
 
+[data-post-content] img[data-zoomable] {
+  border-radius: 0.25rem;
+  cursor: zoom-in;
+}
+
+[data-post-content] img[data-zoomable]:focus-visible {
+  outline: none;
+}
+
+/*
+ * Rendered in the top layer via showModal(), so it escapes the transformed
+ * ancestors created by .page-appearance and the full-bleed post wrapper.
+ */
+.image-zoom-dialog {
+  position: fixed;
+  display: none;
+  inset: 0;
+  width: 100vw;
+  max-width: 100vw;
+  height: 100dvh;
+  max-height: 100dvh;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  background-color: transparent;
+}
+
+/* Fades on its own so the zoomed image never changes opacity. */
+.image-zoom-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgb(244 244 245 / 0.94);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+}
+
+.dark .image-zoom-backdrop {
+  background-color: rgb(17 24 39 / 0.94);
+}
+
+.image-zoom-dialog[open] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* The dialog fills the viewport and paints the backdrop itself. */
+.image-zoom-dialog::backdrop {
+  background: transparent;
+}
+
+.image-zoom-dialog-scroll[open] {
+  display: block;
+  overflow: auto;
+}
+
+.image-zoom-figure {
+  position: relative;
+  z-index: 1;
+  width: auto;
+  height: auto;
+  max-width: 92vw;
+  max-height: 92dvh;
+  border-radius: 0.25rem;
+  /* The FLIP keyframes offset the top-left corner, so it must be the origin. */
+  transform-origin: top left;
+  cursor: zoom-out;
+  will-change: transform;
+}
+
+.image-zoom-dialog:not(.image-zoom-dialog-scroll) .image-zoom-figure {
+  touch-action: none;
+}
+
+/* Shown at natural size and panned, so it must not be clamped to the viewport. */
+.image-zoom-dialog-scroll .image-zoom-figure {
+  display: block;
+  max-width: none;
+  max-height: none;
+  margin: 4dvh auto;
+}
+
+/*
+ * Same box and placement as the header icon buttons (p-3 around a 20px icon,
+ * see icon-button-styles.ts), so it lands exactly on the theme toggle.
+ */
+.image-zoom-close {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.25rem;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 9999px;
+  background-color: rgb(255 255 255 / 0.9);
+  color: #111827;
+  cursor: pointer;
+  transition:
+    color 150ms ease-out,
+    background-color 150ms ease-out;
+}
+
+.image-zoom-close svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+@media (width >= 40rem) {
+  .image-zoom-close {
+    right: 1rem;
+  }
+}
+
+.image-zoom-close:hover {
+  color: var(--color-accent);
+}
+
+/* showModal() focuses this button on open, so the ring would show every time. */
+.image-zoom-close:focus,
+.image-zoom-close:focus-visible {
+  outline: none;
+}
+
+.dark .image-zoom-close {
+  background-color: rgb(17 24 39 / 0.9);
+  color: #ffffff;
+}
+
+@media print {
+  .image-zoom-dialog {
+    display: none !important;
+  }
+}
+
 .page-appearance {
   animation: page-appearance 360ms ease-out both;
 }
@@ -146,6 +286,10 @@ a.underline:hover,
   .view-counter-value,
   .view-counter-skeleton {
     animation: none;
+  }
+
+  .image-zoom-close {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
Click an image in a post to open it in a lightbox.

## Approach

A single delegated client island (`PostImageZoom`) mounted next to `[data-post-content]`, rather than a wrapper per image. Raw `<img>` tags in MDX never pass through `PostImage` (MDX does not substitute explicit JSX), so a wrapper would have missed the 6 raw images — 5 GIFs and one remote giphy. `post-image.tsx`, `markdownToHtml.ts` and every MDX file are untouched; `rounded`, `sizes`, the next/image `srcSet` and the page's RSC-ness all stay as they were.

The overlay is a native `<dialog>` + `showModal()`. `.page-appearance` and the full-bleed post wrapper are permanent transformed ancestors, so `position: fixed` is containing-block-trapped; the top layer escapes it without a portal, and brings a focus trap, `inert` background and focus restore along with it. The overlay image reuses the source's `currentSrc`, so opening costs zero network requests, needs no `remotePatterns` for the remote GIF, and never sends animated GIFs through the image optimizer.

## Sizing

Fit-to-viewport alone would have *shrunk* the most common images. Measured across all 160 assets: wide screenshots (2796×1419) are heavily downscaled in the 672px column and gain from fitting, but 24 tall ones (1179×2556) already render at 672×1457 — taller than the viewport. So the mode is picked per click: if fitting does not magnify by at least 1.2×, the image is shown at natural size and panned instead.

| Image | In article | In overlay | Mode |
|---|---|---|---|
| 2796×1419 | 672 | 1178 (1.75×) | contain |
| 946×882 | 672 | 946 (1.41×) | scroll |
| 946×1764 | 672 | 946 (1.41×) | scroll |

Without this, a 2796px screenshot on a 375px phone zoomed to 345px — no magnification at all.

## Behaviour

Opens on click and on Enter/Space. Closes on Escape, the close button, backdrop click, click on the image, wheel, and drag-to-dismiss. The source image is hidden with `visibility: hidden` while open, so layout is preserved and CLS stays 0. Escape is handled with an explicit `keydown` listener because a modal dialog does not reliably fire `cancel` (Chrome only sends a close request once per user activation). Motion is a FLIP transform via `Element.animate()`; only the backdrop fades, so the image itself never changes opacity and reads as growing out of the article. `prefers-reduced-motion` falls back to a short crossfade. Progressive enhancement: without JS nothing changes, and the `zoom-in` cursor only appears after hydration.

Excluded from zooming: images inside links, `react-tweet` media, and anything marked `[data-no-zoom]`. Broken images report no dimensions and simply do not open.

## Validation

- `npm run lint` and `npm run build` clean; all 37 posts still prerender as `● (SSG)`.
- Client JS +1.9 kB gzip (208561 → 206695, per-file gzip on clean builds).
- Verified with real clicks and key presses in Chrome 148: open/close on every path, focus restored to the source image, source visibility restored every time, FLIP lands within 1px of the source, dark/light both correct, GIF opens unoptimized and keeps playing, remote giphy opens with zero new requests.
- Close button matches the header theme toggle pixel for pixel (44×44 at the same offsets, 20px Feather icon) at both breakpoints.

Not verified: Safari and Firefox (`<dialog>` top layer, `dvh`, `backdrop-filter`, and iOS background scroll behind a modal), and touch swipe on a real device — only Chrome and a mouse were available.

## Known follow-ups

The overlay reuses the srcset candidate chosen for the 672px column, so at natural size it is upscaled — measured 1.46× on a DPR-2 display for a 2796px asset, and worse on non-Retina. Fixing it means background-loading a larger candidate on open. Also: wheel-to-close has no delta threshold, the cover image is not zoomable, and there is no visible keyboard focus indicator (removed by request).
